### PR TITLE
releaseutil: fix sort ordering

### DIFF
--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -17,11 +17,9 @@ package action
 
 import (
 	"bytes"
-	"sort"
 	"time"
 
 	"github.com/pkg/errors"
-
 	"helm.sh/helm/v3/pkg/release"
 	helmtime "helm.sh/helm/v3/pkg/time"
 )
@@ -37,9 +35,6 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 			}
 		}
 	}
-
-	// hooke are pre-ordered by kind, so keep order stable
-	sort.Stable(hookByWeight(executingHooks))
 
 	for _, h := range executingHooks {
 		// Set default delete policy to before-hook-creation
@@ -105,18 +100,6 @@ func (cfg *Configuration) execHook(rl *release.Release, hook release.HookEvent, 
 	}
 
 	return nil
-}
-
-// hookByWeight is a sorter for hooks
-type hookByWeight []*release.Hook
-
-func (x hookByWeight) Len() int      { return len(x) }
-func (x hookByWeight) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
-func (x hookByWeight) Less(i, j int) bool {
-	if x[i].Weight == x[j].Weight {
-		return x[i].Name < x[j].Name
-	}
-	return x[i].Weight < x[j].Weight
 }
 
 // deleteHookByPolicy deletes a hook if the hook policy instructs it to

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"helm.sh/helm/v3/pkg/release"
 	helmtime "helm.sh/helm/v3/pkg/time"
 )

--- a/pkg/releaseutil/kind_sorter.go
+++ b/pkg/releaseutil/kind_sorter.go
@@ -118,13 +118,24 @@ func sortManifestsByKind(manifests []Manifest, ordering KindSortOrder) []Manifes
 	return manifests
 }
 
-// sort hooks by kind, using an out-of-place sort to preserve the input parameters.
-//
-// Results are sorted by 'ordering', keeping order of items with equal kind/priority
-func sortHooksByKind(hooks []*release.Hook, ordering KindSortOrder) []*release.Hook {
+// sortHooks sorts hooks by weight, kind, and finally by name.
+// Kind order is defined by ordering.
+func sortHooks(hooks []*release.Hook, ordering KindSortOrder) []*release.Hook {
 	h := hooks
+
+	// Sort first by name, the least important ordering.
+	sort.Slice(h, func(i, j int) bool {
+		return h[i].Name < h[j].Name
+	})
+
+	// Then sort by kind, keeping equal elements in their original order (Stable).
 	sort.SliceStable(h, func(i, j int) bool {
 		return lessByKind(h[i], h[j], h[i].Kind, h[j].Kind, ordering)
+	})
+
+	// Finally, sort by weight, again keeping equal elements in their original order.
+	sort.SliceStable(h, func(i, j int) bool {
+		return h[i].Weight < h[j].Weight
 	})
 
 	return h

--- a/pkg/releaseutil/manifest_sorter.go
+++ b/pkg/releaseutil/manifest_sorter.go
@@ -108,7 +108,7 @@ func SortManifests(files map[string]string, apis chartutil.VersionSet, ordering 
 		}
 	}
 
-	return sortHooksByKind(result.hooks, ordering), sortManifestsByKind(result.generic, ordering), nil
+	return sortHooks(result.hooks, ordering), sortManifestsByKind(result.generic, ordering), nil
 }
 
 // sort takes a manifestFile object which may contain multiple resource definition


### PR DESCRIPTION
Fixes https://github.com/helm/helm/issues/10768

We have chose to fix this by removing the second sort step, that was performed only on installation time, and instead sort everything when templates are rendered. This might cause the output of `helm template` to change, as previously it was not ordered by weight but now will be.